### PR TITLE
Fixed Typo /carts in a date range

### DIFF
--- a/views/shared/cartDocs.ejs
+++ b/views/shared/cartDocs.ejs
@@ -111,7 +111,7 @@
 
 
 <h3 id="c-date">Get carts in a date range</h3>
-<pre><code>fetch('<span class="c-api">https://fakestoreapi.com/carts/startdate=2019-12-10&enddate=2020-10-10'</span>)
+<pre><code>fetch('<span class="c-api">https://fakestoreapi.com/carts?startdate=2019-12-10&enddate=2020-10-10'</span>)
             .then(res=>res.json())
             .then(json=>console.log(json))</code></pre>
 <p>


### PR DESCRIPTION
CORRECTION issue #65 
> /carts/startdate=2019-12-10&enddate=2020-10-10 => ERROR because **/** before **startdate**

![image](https://user-images.githubusercontent.com/70981701/212841521-5f8117f1-f135-44da-b091-30b8827d2898.png)


> FIXED: /carts?startdate=2019-12-10&enddate=2020-10-10  => Use **?** instead of **/**

![image](https://user-images.githubusercontent.com/70981701/212842193-d9a34991-e93f-4e53-8563-83bd4828283d.png)
