### PR TITLE
docs: 📝 fix incorrect path from /products/products/categories to /products/categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ GET:
 - /products/1 (get specific product based on id)
 - /products?limit=5 (limit return results )
 - /products?sort=desc (asc|desc get products in ascending or descending orders (default to asc))
-- /products/products/categories (get all categories)
+- /products/categories (get all categories)
 - /products/category/jewelery (get all products in specific category)
 - /products/category/jewelery?sort=desc (asc|desc get products in ascending or descending orders (default to asc))
 


### PR DESCRIPTION
# 📄 Pull Request Description

This pull request updates an incorrect documentation path.

Previously, the path was written as `/products/products/categories`, which does not exist and results in a 404 error when accessed. This was likely a duplication error or typo in the URL.

The correct path should be `/products/categories`, and this fix ensures that users are directed to the appropriate endpoint without confusion or broken links.

# ✅ Changes
Fixed the path from `/products/products/categories` to `/products/categories` in the README.